### PR TITLE
refactor(STUDY-169): word break 적용

### DIFF
--- a/src/components/ui/useToast.tsx
+++ b/src/components/ui/useToast.tsx
@@ -65,4 +65,3 @@ export const useToast = () => {
     if (!ctx) throw new Error("useToast must be used within a ToastProvider");
     return ctx.toast;
 };
-

--- a/src/index.css
+++ b/src/index.css
@@ -125,6 +125,7 @@
 @layer base {
     * {
         @apply border-border outline-ring/50;
+        word-break: keep-all;
     }
 
     body {

--- a/src/index.css
+++ b/src/index.css
@@ -126,6 +126,7 @@
     * {
         @apply border-border outline-ring/50;
         word-break: keep-all;
+        overflow-wrap: anywhere;
     }
 
     body {

--- a/src/pages/AttendancePage.tsx
+++ b/src/pages/AttendancePage.tsx
@@ -7,7 +7,6 @@ import {
     XCircle,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useToast } from "@/components/ui/useToast";
 import { Button } from "@/components/ui/button";
 import {
     Card,

--- a/src/pages/CreateStudyPage.tsx
+++ b/src/pages/CreateStudyPage.tsx
@@ -3,7 +3,6 @@ import StudyFormContent from "@/components/study/StudyFormContent";
 import Header from "@/components/ui/Header";
 import { useToast } from "@/components/ui/useToast";
 import { StudyFormProvider } from "@/hooks/useStudyForm";
-import { useToast } from "@/components/ui/useToast";
 
 const CreateStudyPage = () => {
     const navigate = useNavigate();

--- a/src/pages/EditStudyPage.tsx
+++ b/src/pages/EditStudyPage.tsx
@@ -2,7 +2,6 @@ import StudyFormContent from "@/components/study/StudyFormContent";
 import Header from "@/components/ui/Header";
 import { useToast } from "@/components/ui/useToast";
 import { StudyFormProvider } from "@/hooks/useStudyForm";
-import { useToast } from "@/components/ui/useToast";
 
 interface EditStudyProps {
     studyId: number;

--- a/src/pages/StudyMembersPage.tsx
+++ b/src/pages/StudyMembersPage.tsx
@@ -1,6 +1,5 @@
 import { Crown, User, UserX } from "lucide-react";
 import { useState } from "react";
-import { useToast } from "@/components/ui/useToast";
 import {
     AlertDialog,
     AlertDialogAction,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * CSS에서 단어가 임의로 줄바꿈되지 않도록 기본 스타일에 `word-break: keep-all;` 속성이 추가되었고, `overflow-wrap: anywhere;` 속성도 함께 적용되었습니다.

* **Refactor**
  * 중복된 import 문이 제거되어 코드가 더 깔끔해졌습니다.  
  * 사용하지 않는 import 문이 삭제되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->