### PR TITLE
feat(STUDY-199): 스터디 상세 조회 패칭 추가

### DIFF
--- a/src/pages/StudyDetailPage.tsx
+++ b/src/pages/StudyDetailPage.tsx
@@ -29,8 +29,11 @@ import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/useToast";
 import { apiClient } from "@/lib/apiClient";
 import { API_ENDPOINTS } from "@/lib/apiEndpoints";
-import type { StudyDetail } from "@/types/study";
-
+import {
+  StudyCategoryLabels,
+  StudyRecruitmentMethod,
+  type StudyDetail,
+} from "@/types/study";
 interface StudyDetailProps {
     studyId: number;
     onBack: () => void;
@@ -117,7 +120,7 @@ const StudyDetailPage = ({
     const handleApply = async () => {
         setIsApplying(true);
         await new Promise((resolve) => setTimeout(resolve, 1000));
-        if (study.recruitmentMethod === "FCFS") {
+        if (study.recruitmentMethod === StudyRecruitmentMethod.FCFS) {
             setUserApplicationStatus("approved");
             toast({
                 description:
@@ -201,7 +204,7 @@ const StudyDetailPage = ({
                                         variant="outline"
                                         className="border-gray-300 text-gray-600"
                                     >
-                                        #{study.category}
+                                    #{StudyCategoryLabels[study.category]}
                                     </Badge>
                                     {userApplicationStatus &&
                                         getApplicationStatusBadge(
@@ -381,7 +384,7 @@ const StudyDetailPage = ({
                                         모집 방법
                                     </Label>
                                     <p className="mt-1 text-gray-700">
-                                        {study.recruitmentMethod === "FCFS"
+                                        {study.recruitmentMethod === StudyRecruitmentMethod.FCFS
                                             ? "선착순 모집"
                                             : "지원서 심사"}
                                     </p>
@@ -422,7 +425,7 @@ const StudyDetailPage = ({
                                                   "rejected"
                                                 ? "신청 결과"
                                                 : study.recruitmentMethod ===
-                                                    "FCFS"
+                                                    StudyRecruitmentMethod.FCFS
                                                   ? "지원하기"
                                                   : "지원서 작성"}
                                     </CardTitle>
@@ -550,7 +553,7 @@ const StudyDetailPage = ({
 
                                     {!userApplicationStatus &&
                                         (study.recruitmentMethod ===
-                                        "APPLICATION" ? (
+                                        StudyRecruitmentMethod.APPLICATION ? (
                                             <>
                                                 <p className="mb-2 text-center text-gray-500 text-xs">
                                                     지원 동기 및 각오를

--- a/src/pages/StudyDetailPage.tsx
+++ b/src/pages/StudyDetailPage.tsx
@@ -6,7 +6,7 @@ import {
     UsersIcon,
     X,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
     AlertDialog,
     AlertDialogAction,
@@ -27,6 +27,9 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/useToast";
+import { apiClient } from "@/lib/apiClient";
+import { API_ENDPOINTS } from "@/lib/apiEndpoints";
+import type { StudyDetail } from "@/types/study";
 
 interface StudyDetailProps {
     studyId: number;
@@ -36,109 +39,9 @@ interface StudyDetailProps {
     onViewMembers?: (studyId: number) => void;
     onManageAttendance?: (studyId: number) => void;
     isOwner?: boolean;
-    currentUserId?: string;
     initialUserApplicationStatus?: "approved" | "pending" | "rejected" | null;
+    currentUserId: string;
 }
-
-const studyDetailData = {
-    1: {
-        id: 1,
-        title: "Spring과 함께 백엔드 개발자 되기",
-        category: "LANGUAGE",
-        level: "INTERMEDIATE",
-        description: `Spring Framework를 활용한 백엔드 개발 스터디입니다.
-실무에서 사용되는 Spring Boot, Spring Security, JPA 등을 학습하며
-실제 프로젝트를 통해 백엔드 개발 역량을 키워나갑니다.
-
-초보자도 참여할 수 있도록 기초부터 차근차근 진행하며,
-팀 프로젝트를 통해 협업 경험도 쌓을 수 있습니다.`,
-        recruitmentMethod: "APPLICATION",
-        participantCount: 10,
-        maxParticipants: 20,
-        schedule: "매주 화, 목 19:00-21:00",
-        curricula:
-            "1주차: Spring Boot 기초 및 환경 설정\n2주차: Spring MVC 패턴과 REST API\n3주차: 데이터베이스 연동 (JPA, Hibernate)\n4주차: Spring Security 인증/인가\n5주차: 테스트 코드 작성 (JUnit, Mockito)\n6주차: 팀 프로젝트 기획 및 설계\n7주차: 팀 프로젝트 개발\n8주차: 프로젝트 발표 및 코드 리뷰",
-        qualifications:
-            "Java 기초 문법을 알고 있는 분\n객체지향 프로그래밍에 대한 기본 이해\n데이터베이스 기초 지식 (SQL)\nGit 사용 경험 (기초 수준)\n매주 정기 모임 참석 가능한 분",
-        instructor: "관리자",
-        status: "모집중",
-        ownerId: "user123",
-    },
-    2: {
-        id: 2,
-        title: "React 입문",
-        category: "LANGUAGE",
-        level: "BASIC",
-        description: `React를 처음 배우는 분들을 위한 입문 스터디입니다.
-JavaScript 기초부터 React의 핵심 개념까지 차근차근 학습합니다.
-
-실습 위주로 진행되며, 간단한 웹 애플리케이션을 만들어보면서
-React의 동작 원리를 이해할 수 있습니다.`,
-        recruitmentMethod: "FCFS",
-        participantCount: 10,
-        maxParticipants: 20,
-        schedule: "매주 토 14:00-17:00",
-        curricula:
-            "1주차: JavaScript ES6+ 문법 복습\n2주차: React 기초 (JSX, 컴포넌트)\n3주차: State와 Props 이해하기\n4주차: 이벤트 처리와 조건부 렌더링\n5주차: React Hooks (useState, useEffect)\n6주차: 미니 프로젝트 (Todo App 만들기)",
-        qualifications:
-            "HTML, CSS 기초 지식\nJavaScript 기본 문법 이해\n프로그래밍 경험 (언어 무관)\n학습 의지가 강한 분",
-        instructor: "관리자",
-        status: "모집중",
-        ownerId: "user124",
-    },
-    3: {
-        id: 3,
-        title: "Python 데이터 분석",
-        category: "LANGUAGE",
-        level: "INTERMEDIATE",
-        description: `Python과 데이터 분석 라이브러리(Pandas, Numpy 등)를 활용한 데이터 분석 실습 중심 스터디입니다.
-실제 데이터셋을 다루며 데이터 전처리, 시각화, 통계 분석, 간단한 머신러닝까지 경험할 수 있습니다.`,
-        recruitmentMethod: "APPLICATION",
-        participantCount: 15,
-        maxParticipants: 20,
-        schedule: "주 2회",
-        curricula:
-            "1주차: Python 데이터 분석 환경 구축\n2주차: Pandas 기초와 데이터 다루기\n3주차: 데이터 시각화(Matplotlib, Seaborn)\n4주차: 통계 분석 기초\n5주차: 머신러닝 개요 및 실습\n6주차: 프로젝트 실습",
-        qualifications:
-            "Python 기초 문법 이해\n데이터 분석에 관심 있는 분\n노트북 지참 가능자",
-        instructor: "관리자",
-        status: "진행중",
-        ownerId: "user125",
-    },
-    4: {
-        id: 4,
-        title: "Flutter 모바일 앱 개발",
-        category: "LANGUAGE",
-        level: "ADVANCED",
-        description: `Flutter를 활용한 모바일 앱 개발 심화 스터디입니다.
-실제 앱을 기획하고 개발하며, 퍼블리싱까지 경험할 수 있습니다.`,
-        recruitmentMethod: "FCFS",
-        participantCount: 8,
-        maxParticipants: 15,
-        schedule: "주 3회",
-        curricula:
-            "1주차: Flutter 개발 환경 구축\n2주차: 위젯과 레이아웃 이해\n3주차: 상태 관리(BLoC, Provider)\n4주차: 네트워크 통신 및 API 연동\n5주차: 실전 앱 프로젝트",
-        qualifications:
-            "Dart/Flutter 개발 경험\n모바일 앱 개발에 관심 있는 분\n팀 프로젝트 경험자 우대",
-        instructor: "관리자",
-        status: "모집중",
-        ownerId: "user126",
-    },
-};
-
-const initialUserApplicationStatus: Record<
-    string,
-    Record<number, "approved" | "pending" | "rejected">
-> = {
-    user123: {
-        1: "approved",
-        2: "pending",
-        3: "approved",
-    },
-    user456: {
-        1: "pending",
-    },
-};
 
 const StudyDetailPage = ({
     studyId,
@@ -148,28 +51,67 @@ const StudyDetailPage = ({
     onViewMembers,
     onManageAttendance,
     isOwner = false,
-    currentUserId = "user123",
 }: StudyDetailProps) => {
     const [applicationText, setApplicationText] = useState("");
     const [isApplying, setIsApplying] = useState(false);
     const [isCancelling, setIsCancelling] = useState(false);
     const [isApplicationModalOpen, setIsApplicationModalOpen] = useState(false);
+    const [study, setStudy] = useState<StudyDetail | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
     const toast = useToast();
 
     const [userApplicationStatus, setUserApplicationStatus] = useState<
         "approved" | "pending" | "rejected" | null
-    >(
-        typeof initialUserApplicationStatus === "string"
-            ? initialUserApplicationStatus
-            : initialUserApplicationStatus && currentUserId
-              ? (initialUserApplicationStatus[currentUserId]?.[studyId] ?? null)
-              : null
-    );
+    >(null);
 
-    const study = studyDetailData[studyId as keyof typeof studyDetailData];
+    useEffect(() => {
+        const fetchStudy = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const data: StudyDetail = await apiClient
+                    .get(`${API_ENDPOINTS.STUDIES}/${studyId}`)
+                    .json();
+                setStudy(data);
+            } catch (err) {
+                if (err instanceof Error) {
+                    setError(err.message);
+                } else {
+                    setError("알 수 없는 오류가 발생했습니다.");
+                }
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchStudy();
+    }, [studyId]);
+
+    if (loading) {
+        return (
+            <div className="flex min-h-screen items-center justify-center bg-gray-50">
+                <div className="text-gray-500">
+                    스터디 정보를 불러오는 중...
+                </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="flex min-h-screen items-center justify-center bg-gray-50">
+                <div className="text-red-500">{error}</div>
+            </div>
+        );
+    }
 
     if (!study) {
-        return <div>스터디를 찾을 수 없습니다.</div>;
+        return (
+            <div className="flex min-h-screen items-center justify-center bg-gray-50">
+                <div className="text-gray-500">스터디를 찾을 수 없습니다.</div>
+            </div>
+        );
     }
 
     const handleApply = async () => {
@@ -241,9 +183,19 @@ const StudyDetailPage = ({
                                 <div className="mb-2 flex items-center gap-2">
                                     <Badge
                                         variant="secondary"
-                                        className="bg-blue-100 text-blue-800"
+                                        className={`${
+                                            study.participantCount <
+                                                study.maxParticipants ||
+                                            study.maxParticipants === 0
+                                                ? "bg-blue-100 text-blue-800"
+                                                : "bg-gray-100 text-gray-800"
+                                        }`}
                                     >
-                                        {study.status}
+                                        {study.participantCount <
+                                            study.maxParticipants ||
+                                        study.maxParticipants === 0
+                                            ? "모집중"
+                                            : "진행중"}
                                     </Badge>
                                     <Badge
                                         variant="outline"
@@ -470,7 +422,7 @@ const StudyDetailPage = ({
                                                   "rejected"
                                                 ? "신청 결과"
                                                 : study.recruitmentMethod ===
-                                                    "선착순"
+                                                    "FCFS"
                                                   ? "지원하기"
                                                   : "지원서 작성"}
                                     </CardTitle>

--- a/src/types/study.ts
+++ b/src/types/study.ts
@@ -59,3 +59,18 @@ export interface StudyListItem {
     schedule: string;
     instructor: string;
 }
+
+export interface StudyDetail {
+    id: number;
+    title: string;
+    category: StudyCategory;
+    level: StudyLevel;
+    description: string;
+    recruitmentMethod: StudyRecruitmentMethod;
+    participantCount: number;
+    maxParticipants: number;
+    schedule: string;
+    curricula: string;
+    qualifications: string;
+    instructor: string;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 스터디 상세가 서버에서 실시간으로 로드되며, 콘텐츠 표시 전 전면 로딩/에러 화면 제공.
  - 신청 흐름이 개선되어 모집 방식에 따라 모달 기반 작성(신청) 또는 즉시 지원 경로를 구분 처리.
  - 스터디 상세를 위한 상세 데이터 타입이 추가되어 UI에 반영.

- **버그 수정**
  - 존재하지 않는 스터디 접근 시 명확한 “찾을 수 없음” 메시지 표시.

- **주의(호환성)**
  - 현재 사용자 ID 전달이 필수로 변경되어 호출 시 제공 필요.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->