### PR TITLE
fix(STUDY-228): 커리큘럼, 지원 자격 타입을 dto 형식에 맞게 문자열로 수정

### DIFF
--- a/src/components/study-detail/StudyContent.tsx
+++ b/src/components/study-detail/StudyContent.tsx
@@ -31,11 +31,11 @@ export const StudyContent = ({ study }: StudyContentProps) => {
                 <CardContent>
                     <div className="space-y-3">
                         {study.curricula
-                            .split("\n")
+                            .split(/\r?\n/)
                             .filter((item) => item.trim() !== "")
-                            .map((item: string) => (
+                            .map((item: string, idx) => (
                                 <div
-                                    key={item.substring(0, 20)}
+                                    key={`${idx}-${item.substring(0, 20)}`}
                                     className="flex items-start"
                                 >
                                     <CheckCircle className="mt-0.5 mr-3 h-5 w-5 flex-shrink-0 text-blue-600" />
@@ -55,11 +55,11 @@ export const StudyContent = ({ study }: StudyContentProps) => {
                 <CardContent>
                     <div className="space-y-2">
                         {study.qualifications
-                            .split("\n")
+                            .split(/\r?\n/)
                             .filter((qualification) => qualification.trim() !== "")
-                            .map((qualification: string) => (
+                            .map((qualification: string, idx) => (
                                 <div
-                                    key={qualification.substring(0, 20)}
+                                    key={`${idx}-${qualification.substring(0, 20)}`}
                                     className="flex items-start"
                                 >
                                     <span className="mt-2 mr-3 h-2 w-2 flex-shrink-0 rounded-full bg-gray-400" />

--- a/src/components/study-detail/StudyContent.tsx
+++ b/src/components/study-detail/StudyContent.tsx
@@ -30,15 +30,18 @@ export const StudyContent = ({ study }: StudyContentProps) => {
                 </CardHeader>
                 <CardContent>
                     <div className="space-y-3">
-                        {study.curricula.split("\n").map((item: string) => (
-                            <div
-                                key={item.substring(0, 20)}
-                                className="flex items-start"
-                            >
-                                <CheckCircle className="mt-0.5 mr-3 h-5 w-5 flex-shrink-0 text-blue-600" />
-                                <span className="text-gray-700">{item}</span>
-                            </div>
-                        ))}
+                        {study.curricula
+                            .split("\n")
+                            .filter((item) => item.trim() !== "")
+                            .map((item: string) => (
+                                <div
+                                    key={item.substring(0, 20)}
+                                    className="flex items-start"
+                                >
+                                    <CheckCircle className="mt-0.5 mr-3 h-5 w-5 flex-shrink-0 text-blue-600" />
+                                    <span className="text-gray-700">{item}</span>
+                                </div>
+                            ))}
                     </div>
                 </CardContent>
             </Card>
@@ -53,6 +56,7 @@ export const StudyContent = ({ study }: StudyContentProps) => {
                     <div className="space-y-2">
                         {study.qualifications
                             .split("\n")
+                            .filter((qualification) => qualification.trim() !== "")
                             .map((qualification: string) => (
                                 <div
                                     key={qualification.substring(0, 20)}

--- a/src/hooks/useStudyForm.tsx
+++ b/src/hooks/useStudyForm.tsx
@@ -169,8 +169,8 @@ export const useStudyForm = (
                       ? Number(data.maxParticipants)
                       : null,
             schedule: data.schedule,
-            curricula: filteredCurriculum,
-            qualifications: filteredRequirements,
+            curricula: filteredCurriculum.join("\n"),
+            qualifications: filteredRequirements.join("\n"),
         };
 
         mutation.mutate(payload);

--- a/src/lib/createStudyApi.ts
+++ b/src/lib/createStudyApi.ts
@@ -15,8 +15,8 @@ export interface CreateStudyPayload {
     recruitmentMethod: StudyRecruitmentMethod;
     maxParticipants: number | null;
     schedule: string;
-    curricula: string[];
-    qualifications: string[];
+    curricula: string;
+    qualifications: string;
 }
 
 export async function createStudy(

--- a/src/pages/EditStudyPage.tsx
+++ b/src/pages/EditStudyPage.tsx
@@ -104,11 +104,11 @@ const EditStudyPage = ({ studyId, onBack }: EditStudyProps) => {
             study.maxParticipants === 0 ? "unlimited" : "limited",
         schedule: study.schedule,
         curriculum: study.curricula
-            .split("\n")
+            .split(/\r?\n/)
             .filter((v) => v.trim() !== "")
             .map((v) => ({ value: v })),
         requirements: study.qualifications
-            .split("\n")
+            .split(/\r?\n/)
             .filter((v) => v.trim() !== "")
             .map((v) => ({ value: v })),
     };

--- a/src/pages/EditStudyPage.tsx
+++ b/src/pages/EditStudyPage.tsx
@@ -103,9 +103,13 @@ const EditStudyPage = ({ studyId, onBack }: EditStudyProps) => {
         maxParticipantsLimitType:
             study.maxParticipants === 0 ? "unlimited" : "limited",
         schedule: study.schedule,
-        curriculum: study.curricula.split("\n").map((v) => ({ value: v })),
+        curriculum: study.curricula
+            .split("\n")
+            .filter((v) => v.trim() !== "")
+            .map((v) => ({ value: v })),
         requirements: study.qualifications
             .split("\n")
+            .filter((v) => v.trim() !== "")
             .map((v) => ({ value: v })),
     };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 버그 수정
  * 커리큘럼과 자격요건에서 빈 줄이 더 이상 표시되지 않아 불필요한 공백 항목 없이 깔끔한 목록이 제공됩니다.
  * 편집 화면의 초기값에서 공백/빈 항목을 자동으로 제거하여 빈 항목이 추가되거나 제출되는 현상을 방지합니다.
* 개선
  * 보기와 편집 간 입력 처리를 일관되게 정비해 항목 표시와 제출 결과가 예측 가능하고 안정적으로 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->