### PR TITLE
refactor(STUDY-214): 지원서 작성 창 크기 조정

### DIFF
--- a/src/components/study-detail/ApplicationSection.tsx
+++ b/src/components/study-detail/ApplicationSection.tsx
@@ -189,8 +189,7 @@ export const ApplicationSection = ({
                                 onChange={(e) =>
                                     setApplicationText(e.target.value)
                                 }
-                                className="mt-2 max-h-[300px] min-h-[200px] resize-none overflow-y-auto border-gray-300 focus:border-blue-500 focus:ring-blue-500"
-                            />
+                                className="mt-2 max-h-[min(300px,60vh)] min-h-[120px] resize-y overflow-y-auto border-gray-300 focus:border-blue-500 focus:ring-blue-500 sm:min-h-[200px]"                            />
                             <AlertDialogFooter>
                                 <AlertDialogCancel
                                     onClick={() =>

--- a/src/components/study-detail/ApplicationSection.tsx
+++ b/src/components/study-detail/ApplicationSection.tsx
@@ -175,7 +175,7 @@ export const ApplicationSection = ({
                         open={isApplicationModalOpen}
                         onOpenChange={setIsApplicationModalOpen}
                     >
-                        <AlertDialogContent>
+                        <AlertDialogContent className="max-h-[80vh] max-w-4xl">
                             <AlertDialogHeader>
                                 <AlertDialogTitle>지원서 작성</AlertDialogTitle>
                                 <AlertDialogDescription>
@@ -189,7 +189,7 @@ export const ApplicationSection = ({
                                 onChange={(e) =>
                                     setApplicationText(e.target.value)
                                 }
-                                className="mt-2 min-h-[120px] border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                                className="mt-2 max-h-[300px] min-h-[200px] resize-none overflow-y-auto border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                             />
                             <AlertDialogFooter>
                                 <AlertDialogCancel


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 지원서 모달에 최대 높이(80vh)와 최대 너비(4xl)를 지정해 작은 화면에서 넘침을 방지했습니다.
  * 지원서 텍스트 영역 기본 최소 높이를 120px(작은 화면에서는 200px)으로 유지하고 최대 높이를 min(300px,60vh)로 제한했습니다.
  * 텍스트 영역은 세로로만 크기 조절 가능하며 내부 스크롤을 사용하도록 변경했습니다.
  * 포커스·테두리 스타일은 그대로 유지되며 기능 동작은 변경되지 않았습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->