### PR TITLE
fix(STUDY-248): 최대 인원수에 대해서 제한 없음과 관련된 로직 및 오표기 버그 수정

### DIFF
--- a/src/components/study-detail/StudyInfo.tsx
+++ b/src/components/study-detail/StudyInfo.tsx
@@ -42,10 +42,9 @@ export const StudyInfo = ({ study }: StudyInfoProps) => {
                         제한 인원
                     </Label>
                     <p className="mt-1 text-gray-700">
-                        {study.maxParticipants === 0 
+                        {study.maxParticipants === 0
                             ? "제한 없음"
-                            : `${study.participantCount}/${study.maxParticipants}명`
-                        }
+                            : `${study.participantCount}/${study.maxParticipants}명`}
                     </p>
                 </div>
 

--- a/src/components/study-detail/StudyInfo.tsx
+++ b/src/components/study-detail/StudyInfo.tsx
@@ -42,7 +42,10 @@ export const StudyInfo = ({ study }: StudyInfoProps) => {
                         제한 인원
                     </Label>
                     <p className="mt-1 text-gray-700">
-                        {study.participantCount}/{study.maxParticipants}명
+                        {study.maxParticipants === 0 
+                            ? "제한 없음"
+                            : `${study.participantCount}/${study.maxParticipants}명`
+                        }
                     </p>
                 </div>
 

--- a/src/components/study/fields/RecruitmentFields.tsx
+++ b/src/components/study/fields/RecruitmentFields.tsx
@@ -1,6 +1,6 @@
 import { Users } from "lucide-react";
-import { Controller, useWatch } from "react-hook-form";
 import { useEffect } from "react";
+import { Controller, useWatch } from "react-hook-form";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -29,7 +29,11 @@ const RecruitmentFields = () => {
     // "제한 없음"을 선택했을 때 maxParticipants를 "0"으로 설정
     useEffect(() => {
         if (maxParticipantsLimitType === "unlimited") {
-            setValue("maxParticipants", "0");
+            setValue("maxParticipants", "0", {
+                shouldDirty: false,
+                shouldValidate: false,
+                shouldTouch: false,
+            });
         }
     }, [maxParticipantsLimitType, setValue]);
 

--- a/src/components/study/fields/RecruitmentFields.tsx
+++ b/src/components/study/fields/RecruitmentFields.tsx
@@ -1,5 +1,6 @@
 import { Users } from "lucide-react";
 import { Controller, useWatch } from "react-hook-form";
+import { useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -15,6 +16,7 @@ const RecruitmentFields = () => {
         form: {
             control,
             formState: { isDirty },
+            setValue,
         },
         isEditMode,
     } = useStudyFormContext();
@@ -23,6 +25,13 @@ const RecruitmentFields = () => {
         control,
         name: "maxParticipantsLimitType",
     });
+
+    // "제한 없음"을 선택했을 때 maxParticipants를 "0"으로 설정
+    useEffect(() => {
+        if (maxParticipantsLimitType === "unlimited") {
+            setValue("maxParticipants", "0");
+        }
+    }, [maxParticipantsLimitType, setValue]);
 
     return (
         <Card className="border-gray-200">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 스터디 상세 화면에서 인원 제한이 없을 때 “제한 없음”으로 표시하고, 제한이 있을 때는 기존의 “현재/최대명” 형식을 유지합니다.
  * 모집 설정 폼에서 인원 제한을 “무제한”으로 선택하면 최대 인원이 자동으로 0으로 설정되어 폼 상태가 일관되게 유지됩니다. 기존 검증 로직에는 영향을 주지 않습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->