### PR TITLE
fix(STUDY-266): JSON 응답 파싱 에러 픽스

### DIFF
--- a/src/api/enrollmentApi.ts
+++ b/src/api/enrollmentApi.ts
@@ -54,7 +54,16 @@ export async function enrollInStudy(
         );
 
         if (response.status === 201) {
-            return await response.json<EnrollmentResponse>();
+            // body가 비어있을 수 있으므로 예외 처리
+            const text = await response.text();
+            if (!text) {
+                // 서버가 빈 body를 반환한 경우 기본값 반환
+                return {
+                    message: "지원이 완료되었습니다.",
+                    status: "PENDING",
+                };
+            }
+            return JSON.parse(text) as EnrollmentResponse;
         }
 
         throw new Error(`Unexpected response status: ${response.status}`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 스터디 신청 완료(201) 시 서버 응답 본문이 비어도 앱이 정상적으로 완료 메시지("지원이 완료되었습니다.")와 상태(PENDING)를 표시하도록 개선했습니다. 본문이 존재할 경우에는 기존과 동일하게 결과를 보여줍니다. 이로써 예외적인 빈 응답에서도 신청 완료 피드백이 안정적으로 제공되어 오류나 빈 화면이 발생하던 상황을 해소합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->