### PR TITLE
feat: 스터디 개설, 지원 버튼에 애니메이션 추가

### DIFF
--- a/src/components/study-detail/ApplicationSection.tsx
+++ b/src/components/study-detail/ApplicationSection.tsx
@@ -179,12 +179,20 @@ export const ApplicationSection = ({
                     </p>
                     <Button
                         onClick={() => setIsApplicationModalOpen(true)}
-                        className="group relative w-full max-w-xl overflow-hidden bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
+                        disabled={isApplying}
+                        aria-busy={isApplying}
+                        className="group relative w-full max-w-xl overflow-hidden bg-blue-600 text-white transition-colors hover:bg-blue-700 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-60"
                     >
-                        <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
-                            <span className="h-56 w-56 scale-0 transform rounded-full bg-white opacity-0 transition-all duration-500 ease-out group-hover:scale-100 group-hover:opacity-20" />
+                        <span
+                            aria-hidden="true"
+                            className="pointer-events-none absolute inset-0 z-0 flex items-center justify-center"
+                        >
+                            <span
+                                aria-hidden="true"
+                                className="h-56 w-56 scale-0 transform rounded-full bg-white opacity-0 transition-opacity transition-transform duration-500 ease-out group-hover:scale-100 group-hover:opacity-20 motion-reduce:transform-none motion-reduce:transition-none"
+                            />
                         </span>
-                        <span className="relative">
+                        <span className="relative z-10">
                             {isApplying ? "처리 중..." : "지원서 작성하기"}
                         </span>
                     </Button>
@@ -244,12 +252,18 @@ export const ApplicationSection = ({
                         <Button
                             onClick={handleApply}
                             disabled={isApplying || !recruiting}
-                            className="group relative w-full max-w-xl overflow-hidden bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
+                            className="group relative w-full max-w-xl overflow-hidden bg-blue-600 text-white transition-colors hover:bg-blue-700 disabled:opacity-60"
                         >
-                            <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
-                                <span className="h-56 w-56 scale-0 transform rounded-full bg-white opacity-0 transition-all duration-500 ease-out group-hover:scale-100 group-hover:opacity-20" />
+                            <span
+                                aria-hidden="true"
+                                className="pointer-events-none absolute inset-0 z-0 flex items-center justify-center"
+                            >
+                                <span
+                                    aria-hidden="true"
+                                    className="h-56 w-56 scale-0 transform rounded-full bg-white opacity-0 transition-opacity transition-transform duration-500 ease-out group-hover:scale-100 group-hover:opacity-20 motion-reduce:transform-none motion-reduce:transition-none"
+                                />
                             </span>
-                            <span className="relative">
+                            <span className="relative z-10">
                                 {isApplying ? "처리 중..." : "지원하기"}
                             </span>
                         </Button>

--- a/src/components/study-detail/ApplicationSection.tsx
+++ b/src/components/study-detail/ApplicationSection.tsx
@@ -179,10 +179,12 @@ export const ApplicationSection = ({
                     </p>
                     <Button
                         onClick={() => setIsApplicationModalOpen(true)}
-                        className="w-full bg-blue-600 text-white hover:bg-blue-700"
-                        disabled={isApplying}
+                            className="group relative w-full max-w-xl overflow-hidden bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
                     >
-                        {isApplying ? "처리 중..." : "지원서 작성하기"}
+                        <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                            <span className="h-56 w-56 scale-0 transform rounded-full bg-white opacity-0 transition-all duration-500 ease-out group-hover:scale-100 group-hover:opacity-20" />
+                        </span>
+                        <span className="relative">{isApplying ? "처리 중..." : "지원서 작성하기"}</span>
                     </Button>
 
                     {/* 지원서 작성 모달 */}
@@ -236,13 +238,18 @@ export const ApplicationSection = ({
             const recruiting = isStudyRecruiting(study);
             return (
                 <>
-                    <Button
-                        onClick={handleApply}
-                        disabled={isApplying || !recruiting}
-                        className="w-full bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
-                    >
-                        {isApplying ? "처리 중..." : "지원하기"}
-                    </Button>
+                    <div className="flex justify-center">
+                        <Button
+                            onClick={handleApply}
+                            disabled={isApplying || !recruiting}
+                            className="group relative w-full max-w-xl overflow-hidden bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
+                        >
+                            <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                                <span className="h-56 w-56 scale-0 transform rounded-full bg-white opacity-0 transition-all duration-500 ease-out group-hover:scale-100 group-hover:opacity-20" />
+                            </span>
+                            <span className="relative">{isApplying ? "처리 중..." : "지원하기"}</span>
+                        </Button>
+                    </div>
                     <p className="text-center text-gray-500 text-xs">
                         {recruiting
                             ? "선착순으로 모집되며, 정원이 마감되면 자동으로 마감됩니다."

--- a/src/components/study-detail/ApplicationSection.tsx
+++ b/src/components/study-detail/ApplicationSection.tsx
@@ -179,12 +179,14 @@ export const ApplicationSection = ({
                     </p>
                     <Button
                         onClick={() => setIsApplicationModalOpen(true)}
-                            className="group relative w-full max-w-xl overflow-hidden bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
+                        className="group relative w-full max-w-xl overflow-hidden bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
                     >
                         <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
                             <span className="h-56 w-56 scale-0 transform rounded-full bg-white opacity-0 transition-all duration-500 ease-out group-hover:scale-100 group-hover:opacity-20" />
                         </span>
-                        <span className="relative">{isApplying ? "처리 중..." : "지원서 작성하기"}</span>
+                        <span className="relative">
+                            {isApplying ? "처리 중..." : "지원서 작성하기"}
+                        </span>
                     </Button>
 
                     {/* 지원서 작성 모달 */}
@@ -247,7 +249,9 @@ export const ApplicationSection = ({
                             <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
                                 <span className="h-56 w-56 scale-0 transform rounded-full bg-white opacity-0 transition-all duration-500 ease-out group-hover:scale-100 group-hover:opacity-20" />
                             </span>
-                            <span className="relative">{isApplying ? "처리 중..." : "지원하기"}</span>
+                            <span className="relative">
+                                {isApplying ? "처리 중..." : "지원하기"}
+                            </span>
                         </Button>
                     </div>
                     <p className="text-center text-gray-500 text-xs">

--- a/src/pages/StudyListPage.tsx
+++ b/src/pages/StudyListPage.tsx
@@ -31,12 +31,18 @@ const StudyList = ({
             <div className="mb-6 flex w-full justify-end px-6 pt-6">
                 <Button
                     onClick={onCreateStudy}
-                    className="group relative overflow-hidden bg-blue-600 text-white hover:bg-blue-700"
+                    className="group relative overflow-hidden bg-blue-600 text-white transition-colors hover:bg-blue-700"
                 >
-                    <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
-                        <span className="h-56 w-56 scale-0 transform rounded-full bg-white opacity-0 transition-all duration-500 ease-out group-hover:scale-100 group-hover:opacity-20" />
+                    <span
+                        aria-hidden="true"
+                        className="pointer-events-none absolute inset-0 z-0 flex items-center justify-center"
+                    >
+                        <span
+                            aria-hidden="true"
+                            className="h-56 w-56 scale-0 transform rounded-full bg-white opacity-0 transition-opacity transition-transform duration-500 ease-out group-hover:scale-100 group-hover:opacity-20 motion-reduce:transform-none motion-reduce:transition-none"
+                        />
                     </span>
-                    <span className="relative">스터디 개설하기</span>
+                    <span className="relative z-10">스터디 개설하기</span>
                 </Button>
             </div>
             <main className="mx-auto max-w-6xl items-center px-6 pb-6">

--- a/src/pages/StudyListPage.tsx
+++ b/src/pages/StudyListPage.tsx
@@ -31,9 +31,12 @@ const StudyList = ({
             <div className="mb-6 flex w-full justify-end px-6 pt-6">
                 <Button
                     onClick={onCreateStudy}
-                    className="bg-blue-600 text-white hover:bg-blue-700"
+                    className="group relative overflow-hidden bg-blue-600 text-white hover:bg-blue-700"
                 >
-                    스터디 개설하기
+                    <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                        <span className="h-56 w-56 scale-0 transform rounded-full bg-white opacity-0 transition-all duration-500 ease-out group-hover:scale-100 group-hover:opacity-20" />
+                    </span>
+                    <span className="relative">스터디 개설하기</span>
                 </Button>
             </div>
             <main className="mx-auto max-w-6xl items-center px-6 pb-6">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 신청/지원 버튼들에 그룹 기반 호버 오버레이와 페이드/스케일 애니메이션 추가, 라벨을 별도 래핑해 가독성 개선.
  * “스터디 개설하기” 버튼에도 동일한 시각 효과 적용.
  * 버튼의 최대 너비, 정렬, 오버플로우 설정으로 시각적 일관성 강화.

* **접근성**
  * 주요 버튼에 aria-busy 추가로 작업 중 상태 제공.
  * 일부 버튼은 실제 disabled prop 대신 CSS로 비활성화 표현(동작은 동일).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->