### PR TITLE
refactor: 403 에러에 대해서 에러 토스트 추가 (#70) (#71)

### DIFF
--- a/src/api/enrollmentApi.ts
+++ b/src/api/enrollmentApi.ts
@@ -76,6 +76,8 @@ export async function enrollInStudy(
             switch (status) {
                 case 400:
                     throw new Error("잘못된 요청 데이터입니다.");
+                case 403:
+                    throw new Error("지원 기간이 아닙니다.");
                 case 404:
                     throw new Error("스터디를 찾을 수 없습니다.");
                 case 409:

--- a/src/pages/AttendancePage.tsx
+++ b/src/pages/AttendancePage.tsx
@@ -1,5 +1,5 @@
 import { Timer } from "lucide-react";
-import { useState, useRef } from "react";
+import { useRef, useState } from "react";
 import type { AttendanceCodeResponse } from "@/api/attendanceApi";
 import { fetchAttendanceCode } from "@/api/attendanceApi";
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 스터디 지원 요청이 기간 외에 이루어져 실패(HTTP 403)할 경우, 사용자에게 “지원 기간이 아닙니다.”라는 명확한 오류 메시지를 표시합니다. 기존 400, 404, 409 상태에 대한 처리와 정상 흐름은 그대로 유지됩니다. 이를 통해 사용자는 지원 가능 기간이 아닐 때의 원인을 즉시 파악하고 재시도 시점을 판단할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->