### PR TITLE
fix: 지원 상태 대신 사용자 역할에 대해서 판단하도록 수정

### DIFF
--- a/src/components/study-detail/ApplicationSection.tsx
+++ b/src/components/study-detail/ApplicationSection.tsx
@@ -18,6 +18,7 @@ import {
     StudyRecruitmentMethod,
     type UserApplicationStatus,
 } from "@/types/study";
+import { UserRole } from "@/types/user";
 import {
     getApplicationSectionTitle,
     isStudyRecruiting,
@@ -26,6 +27,7 @@ import {
 interface ApplicationSectionProps {
     study: StudyDetail;
     isOwner?: boolean;
+    userRole?: UserRole;
     applicationState: {
         applicationText: string;
         isApplying: boolean;
@@ -45,6 +47,7 @@ interface ApplicationSectionProps {
 export const ApplicationSection = ({
     study,
     isOwner = false,
+    userRole,
     applicationState,
 }: ApplicationSectionProps) => {
     const {
@@ -154,7 +157,7 @@ export const ApplicationSection = ({
         </div>
     );
 
-    const renderApprovedStatus = () => (
+    const renderParticipantStatus = () => (
         <div className="space-y-4">
             <div className="text-center">
                 <p className="mb-2 font-medium text-green-600">
@@ -327,11 +330,14 @@ export const ApplicationSection = ({
     };
 
     const renderContent = () => {
+        // 스터디원 권한이 있는 경우
+        if (userRole === UserRole.PARTICIPANT) {
+            return renderParticipantStatus();
+        }
+
         switch (userApplicationStatus) {
             case "PENDING":
                 return renderPendingStatus();
-            case "APPROVED":
-                return renderApprovedStatus();
             case "REJECTED":
                 return renderRejectedStatus();
             default:

--- a/src/components/study-detail/StudyHeader.tsx
+++ b/src/components/study-detail/StudyHeader.tsx
@@ -91,17 +91,18 @@ export const StudyHeader = ({
     };
 
     const getApplicationStatusBadge = () => {
+        // 스터디원 권한이 있는 경우
+        if (userRole === UserRole.PARTICIPANT) {
+            return (
+                <Badge className="bg-green-100 text-green-800">참여 중</Badge>
+            );
+        }
+
         switch (userApplicationStatus) {
             case ApplicationStatus.PENDING:
                 return (
                     <Badge className="bg-yellow-100 text-yellow-800">
                         신청 대기 중
-                    </Badge>
-                );
-            case ApplicationStatus.APPROVED:
-                return (
-                    <Badge className="bg-green-100 text-green-800">
-                        참여 중
                     </Badge>
                 );
             case ApplicationStatus.REJECTED:
@@ -183,51 +184,50 @@ export const StudyHeader = ({
                         )}
                     </div>
 
-                    {userRole === UserRole.PARTICIPANT &&
-                        !isOwner && (
-                            <div className="w-full shrink-0 border-gray-200 border-t pt-4 md:w-auto md:border-gray-200 md:border-t-0 md:border-l md:pl-4">
-                                <div className="flex items-end gap-2">
-                                    <div className="grid w-full max-w-sm items-center gap-1.5">
-                                        <Label
-                                            htmlFor={`attendance-code-${study.id}`}
-                                            className="font-medium text-sm"
-                                        >
-                                            출석코드
-                                        </Label>
-                                        <Input
-                                            type="text"
-                                            id={`attendance-code-${study.id}`}
-                                            placeholder="4자리 숫자"
-                                            value={attendanceCode}
-                                            onChange={(e) =>
-                                                handleAttendanceCodeChange(
-                                                    e.target.value
-                                                )
-                                            }
-                                            disabled={isSubmitting}
-                                            maxLength={4}
-                                            className="h-9 text-center"
-                                            onKeyDown={(e) => {
-                                                if (e.key === "Enter") {
-                                                    handleAttendanceSubmit();
-                                                }
-                                            }}
-                                        />
-                                    </div>
-                                    <Button
-                                        onClick={handleAttendanceSubmit}
-                                        disabled={
-                                            isSubmitting ||
-                                            attendanceCode.length !== 4
-                                        }
-                                        size="sm"
-                                        className="h-9"
+                    {userRole === UserRole.PARTICIPANT && !isOwner && (
+                        <div className="w-full shrink-0 border-gray-200 border-t pt-4 md:w-auto md:border-gray-200 md:border-t-0 md:border-l md:pl-4">
+                            <div className="flex items-end gap-2">
+                                <div className="grid w-full max-w-sm items-center gap-1.5">
+                                    <Label
+                                        htmlFor={`attendance-code-${study.id}`}
+                                        className="font-medium text-sm"
                                     >
-                                        {isSubmitting ? "제출 중..." : "제출"}
-                                    </Button>
+                                        출석코드
+                                    </Label>
+                                    <Input
+                                        type="text"
+                                        id={`attendance-code-${study.id}`}
+                                        placeholder="4자리 숫자"
+                                        value={attendanceCode}
+                                        onChange={(e) =>
+                                            handleAttendanceCodeChange(
+                                                e.target.value
+                                            )
+                                        }
+                                        disabled={isSubmitting}
+                                        maxLength={4}
+                                        className="h-9 text-center"
+                                        onKeyDown={(e) => {
+                                            if (e.key === "Enter") {
+                                                handleAttendanceSubmit();
+                                            }
+                                        }}
+                                    />
                                 </div>
+                                <Button
+                                    onClick={handleAttendanceSubmit}
+                                    disabled={
+                                        isSubmitting ||
+                                        attendanceCode.length !== 4
+                                    }
+                                    size="sm"
+                                    className="h-9"
+                                >
+                                    {isSubmitting ? "제출 중..." : "제출"}
+                                </Button>
                             </div>
-                        )}
+                        </div>
+                    )}
                 </div>
             </CardHeader>
         </Card>

--- a/src/components/study-detail/StudyHeader.tsx
+++ b/src/components/study-detail/StudyHeader.tsx
@@ -14,11 +14,13 @@ import {
     StudyRecruitmentMethod,
     type UserApplicationStatus,
 } from "@/types/study";
+import { UserRole } from "@/types/user";
 
 interface StudyHeaderProps {
     study: StudyDetail;
     isOwner?: boolean;
     userApplicationStatus?: UserApplicationStatus;
+    userRole?: UserRole;
     onEdit?: (studyId: number) => void;
     onViewApplications?: (studyId: number) => void;
     onViewMembers?: (studyId: number) => void;
@@ -29,6 +31,7 @@ export const StudyHeader = ({
     study,
     isOwner = false,
     userApplicationStatus,
+    userRole,
     onEdit,
     onViewApplications,
     onViewMembers,
@@ -180,7 +183,7 @@ export const StudyHeader = ({
                         )}
                     </div>
 
-                    {userApplicationStatus === ApplicationStatus.APPROVED &&
+                    {userRole === UserRole.PARTICIPANT &&
                         !isOwner && (
                             <div className="w-full shrink-0 border-gray-200 border-t pt-4 md:w-auto md:border-gray-200 md:border-t-0 md:border-l md:pl-4">
                                 <div className="flex items-end gap-2">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 참가자 역할(userRole)에 따라 신청 섹션이 개선되어, 참가자는 전용 상태 화면(참여 중 상태 포함)을 확인할 수 있습니다.
  - 출석 입력란이 기존 승인 상태 대신 사용자 역할(참가자)과 소유자 여부에 따라 표시되어, 참가자(비소유자)에게만 노출됩니다.

- 리팩터링
  - 화면 표시 로직을 역할 기반으로 정리해 일관된 사용자 경험을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->