### PR TITLE
fix: 승인 받고 스터디원이 아닌 경우 방지

### DIFF
--- a/src/components/study-detail/ApplicationSection.tsx
+++ b/src/components/study-detail/ApplicationSection.tsx
@@ -26,6 +26,7 @@ import {
 interface ApplicationSectionProps {
     study: StudyDetail;
     isOwner?: boolean;
+    isMember?: boolean;
     applicationState: {
         applicationText: string;
         isApplying: boolean;
@@ -45,6 +46,7 @@ interface ApplicationSectionProps {
 export const ApplicationSection = ({
     study,
     isOwner = false,
+    isMember = false,
     applicationState,
 }: ApplicationSectionProps) => {
     const {
@@ -327,11 +329,12 @@ export const ApplicationSection = ({
     };
 
     const renderContent = () => {
+        if (isMember) {
+            return renderApprovedStatus();
+        }
         switch (userApplicationStatus) {
             case "PENDING":
                 return renderPendingStatus();
-            case "APPROVED":
-                return renderApprovedStatus();
             case "REJECTED":
                 return renderRejectedStatus();
             default:

--- a/src/components/study-detail/StudyHeader.tsx
+++ b/src/components/study-detail/StudyHeader.tsx
@@ -18,6 +18,7 @@ import {
 interface StudyHeaderProps {
     study: StudyDetail;
     isOwner?: boolean;
+    isMember?: boolean;
     userApplicationStatus?: UserApplicationStatus;
     onEdit?: (studyId: number) => void;
     onViewApplications?: (studyId: number) => void;
@@ -28,6 +29,7 @@ interface StudyHeaderProps {
 export const StudyHeader = ({
     study,
     isOwner = false,
+    isMember = false,
     userApplicationStatus,
     onEdit,
     onViewApplications,
@@ -88,17 +90,16 @@ export const StudyHeader = ({
     };
 
     const getApplicationStatusBadge = () => {
+        if (isMember) {
+            return (
+                <Badge className="bg-green-100 text-green-800">참여 중</Badge>
+            );
+        }
         switch (userApplicationStatus) {
             case ApplicationStatus.PENDING:
                 return (
                     <Badge className="bg-yellow-100 text-yellow-800">
                         신청 대기 중
-                    </Badge>
-                );
-            case ApplicationStatus.APPROVED:
-                return (
-                    <Badge className="bg-green-100 text-green-800">
-                        참여 중
                     </Badge>
                 );
             case ApplicationStatus.REJECTED:
@@ -180,51 +181,50 @@ export const StudyHeader = ({
                         )}
                     </div>
 
-                    {userApplicationStatus === ApplicationStatus.APPROVED &&
-                        !isOwner && (
-                            <div className="w-full shrink-0 border-gray-200 border-t pt-4 md:w-auto md:border-gray-200 md:border-t-0 md:border-l md:pl-4">
-                                <div className="flex items-end gap-2">
-                                    <div className="grid w-full max-w-sm items-center gap-1.5">
-                                        <Label
-                                            htmlFor={`attendance-code-${study.id}`}
-                                            className="font-medium text-sm"
-                                        >
-                                            출석코드
-                                        </Label>
-                                        <Input
-                                            type="text"
-                                            id={`attendance-code-${study.id}`}
-                                            placeholder="4자리 숫자"
-                                            value={attendanceCode}
-                                            onChange={(e) =>
-                                                handleAttendanceCodeChange(
-                                                    e.target.value
-                                                )
-                                            }
-                                            disabled={isSubmitting}
-                                            maxLength={4}
-                                            className="h-9 text-center"
-                                            onKeyDown={(e) => {
-                                                if (e.key === "Enter") {
-                                                    handleAttendanceSubmit();
-                                                }
-                                            }}
-                                        />
-                                    </div>
-                                    <Button
-                                        onClick={handleAttendanceSubmit}
-                                        disabled={
-                                            isSubmitting ||
-                                            attendanceCode.length !== 4
-                                        }
-                                        size="sm"
-                                        className="h-9"
+                    {isMember && !isOwner && (
+                        <div className="w-full shrink-0 border-gray-200 border-t pt-4 md:w-auto md:border-gray-200 md:border-t-0 md:border-l md:pl-4">
+                            <div className="flex items-end gap-2">
+                                <div className="grid w-full max-w-sm items-center gap-1.5">
+                                    <Label
+                                        htmlFor={`attendance-code-${study.id}`}
+                                        className="font-medium text-sm"
                                     >
-                                        {isSubmitting ? "제출 중..." : "제출"}
-                                    </Button>
+                                        출석코드
+                                    </Label>
+                                    <Input
+                                        type="text"
+                                        id={`attendance-code-${study.id}`}
+                                        placeholder="4자리 숫자"
+                                        value={attendanceCode}
+                                        onChange={(e) =>
+                                            handleAttendanceCodeChange(
+                                                e.target.value
+                                            )
+                                        }
+                                        disabled={isSubmitting}
+                                        maxLength={4}
+                                        className="h-9 text-center"
+                                        onKeyDown={(e) => {
+                                            if (e.key === "Enter") {
+                                                handleAttendanceSubmit();
+                                            }
+                                        }}
+                                    />
                                 </div>
+                                <Button
+                                    onClick={handleAttendanceSubmit}
+                                    disabled={
+                                        isSubmitting ||
+                                        attendanceCode.length !== 4
+                                    }
+                                    size="sm"
+                                    className="h-9"
+                                >
+                                    {isSubmitting ? "제출 중..." : "제출"}
+                                </Button>
                             </div>
-                        )}
+                        </div>
+                    )}
                 </div>
             </CardHeader>
         </Card>

--- a/src/pages/StudyDetailPage.tsx
+++ b/src/pages/StudyDetailPage.tsx
@@ -28,6 +28,7 @@ const StudyDetailPage = ({
     // 사용자 역할 확인
     const {
         isInstructor,
+        isParticipant,
         isLoading: isRoleLoading,
         error: roleError,
     } = useUserRole();
@@ -98,6 +99,7 @@ const StudyDetailPage = ({
 
     // 사용자가 이 스터디의 강사인지 확인
     const isOwner = isInstructor(studyId);
+    const isMember = isParticipant(studyId);
 
     return (
         <div className="min-h-screen bg-gray-50">
@@ -110,6 +112,7 @@ const StudyDetailPage = ({
                 <StudyHeader
                     study={study}
                     isOwner={isOwner}
+                    isMember={isMember}
                     userApplicationStatus={userApplicationStatus}
                     onEdit={onEdit}
                     onViewApplications={onViewApplications}
@@ -126,6 +129,7 @@ const StudyDetailPage = ({
                         <ApplicationSection
                             study={study}
                             isOwner={isOwner}
+                            isMember={isMember}
                             applicationState={{
                                 applicationText,
                                 isApplying,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 스터디 상세 화면에서 회원 여부를 인식해 상태 배지를 “참여 중”으로 명확히 표시합니다.
  - 구성원인 경우(방장 제외) 출석 코드 입력/제출 UI가 항상 노출되어 출석 제출이 더 직관적입니다.
  - 신청/승인 상태 표시 로직이 구성원 상태를 우선하여 보다 일관된 상태 표시를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->