### PR TITLE
refactor: 401에러를 제외하고 오류 시 retry 추가

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -35,7 +35,6 @@ export const useAuth = () => {
                     return data;
                 } else {
                     if (response.status === 401) {
-                        setUnauthorized();
                         const error = new Error("Unauthorized");
                         error.name = "AuthError";
                         throw error;

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -32,17 +32,34 @@ export const useAuth = () => {
                     }
                     return data;
                 } else {
-                    setUnauthorized();
+                    // 401 오류는 인증 실패로 간주
+                    if (response.status === 401) {
+                        setUnauthorized();
+                        const error = new Error("Unauthorized");
+                        error.name = "AuthError";
+                        throw error;
+                    }
+                    // 다른 HTTP 오류는 재시도 가능
                     throw new Error("Authentication check failed");
                 }
             } catch (error) {
                 console.error("Auth check failed:", error);
-                setUnauthorized();
+                // AuthError(401)가 아닌 경우만 로그아웃 처리
+                if (!(error instanceof Error && error.name === "AuthError")) {
+                    setUnauthorized();
+                }
                 throw error;
             }
         },
         ...QUERY_OPTIONS_SLOW,
-        retry: 0,
+        retry: (failureCount, error) => {
+            // 401(AuthError)은 재시도하지 않음
+            if (error instanceof Error && error.name === "AuthError") {
+                return false;
+            }
+            // 다른 오류는 2번까지 재시도
+            return failureCount < 2;
+        },
         enabled: status === AuthStatus.LOADING,
     });
 

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -18,7 +18,9 @@ export const useAuth = () => {
         queryFn: async () => {
             setLoading();
             try {
-                const response = await apiClient.get(API_ENDPOINTS.CHECK_AUTH);
+                const response = await apiClient.get(API_ENDPOINTS.CHECK_AUTH, {
+                    throwHttpErrors: false,
+                });
 
                 if (response.ok) {
                     const data = await response.json<{ status: string }>();
@@ -32,19 +34,16 @@ export const useAuth = () => {
                     }
                     return data;
                 } else {
-                    // 401 오류는 인증 실패로 간주
                     if (response.status === 401) {
                         setUnauthorized();
                         const error = new Error("Unauthorized");
                         error.name = "AuthError";
                         throw error;
                     }
-                    // 다른 HTTP 오류는 재시도 가능
                     throw new Error("Authentication check failed");
                 }
             } catch (error) {
                 console.error("Auth check failed:", error);
-                // AuthError(401)가 아닌 경우만 로그아웃 처리
                 if (!(error instanceof Error && error.name === "AuthError")) {
                     setUnauthorized();
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 인증 검사 로직을 개선했습니다. HTTP 401은 즉시 비인가로 처리하고 자동 재시도하지 않습니다. 그 외의 비정상 응답은 즉시 로그아웃 처리를 하지 않고 최대 2회까지 자동 재시도하도록 변경하여 일시적 네트워크 오류에 대한 복원력을 높였습니다. 오류 종류에 따른 처리 분리를 통해 불필요한 로그아웃과 재시도를 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->