### PR TITLE
fix: 스터디 목록 카드 카테고리 하단에 고정

### DIFF
--- a/src/pages/StudyListPage.tsx
+++ b/src/pages/StudyListPage.tsx
@@ -75,7 +75,7 @@ const StudyCard = memo(({ study, onViewStudyDetail }: StudyCardProps) => {
 
   return (
     <Card
-      className="h-[280px] w-full min-w-[250px] cursor-pointer border-gray-200 transition-shadow hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+      className="h-[280px] w-full min-w-[250px] cursor-pointer overflow-hidden border-gray-200 transition-shadow hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       tabIndex={0}
@@ -124,7 +124,7 @@ const StudyCard = memo(({ study, onViewStudyDetail }: StudyCardProps) => {
             </div>
           </div>
 
-          <div className="flex justify-end">
+          <div className="mt-auto flex justify-end">
             <Badge variant="outline" className="border-gray-300 text-gray-600">
               #{StudyCategoryLabels[study.category]}
             </Badge>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 연구 목록 카드의 레이아웃을 개선했습니다. 컨텐츠가 카드 하단에 올바르게 정렬되고 시각적 표현이 더욱 깔끔해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->