### PR TITLE
fix: 스터디 카드 카테고리 하단에 삐져나오는 버그 수정

### DIFF
--- a/src/pages/StudyListPage.tsx
+++ b/src/pages/StudyListPage.tsx
@@ -75,7 +75,7 @@ const StudyCard = memo(({ study, onViewStudyDetail }: StudyCardProps) => {
 
   return (
     <Card
-      className="h-[280px] w-full min-w-[250px] cursor-pointer overflow-hidden border-gray-200 transition-shadow hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+      className="relative h-[280px] w-full min-w-[250px] cursor-pointer overflow-hidden border-gray-200 transition-shadow hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       tabIndex={0}
@@ -118,13 +118,13 @@ const StudyCard = memo(({ study, onViewStudyDetail }: StudyCardProps) => {
                   : `${study.participantCount}/${study.maxParticipants}명`}
               </span>
             </div>
-            <div className="flex items-center">
+          </div>
+
+          <div className="flex shrink-0 items-center justify-between">
+            <div className="flex items-center text-gray-600 text-sm">
               <User className="mr-2 h-4 w-4 shrink-0" />
               <span>{study.instructor}</span>
             </div>
-          </div>
-
-          <div className="mt-auto flex justify-end">
             <Badge variant="outline" className="border-gray-300 text-gray-600">
               #{StudyCategoryLabels[study.category]}
             </Badge>

--- a/src/pages/StudyListPage.tsx
+++ b/src/pages/StudyListPage.tsx
@@ -120,12 +120,15 @@ const StudyCard = memo(({ study, onViewStudyDetail }: StudyCardProps) => {
             </div>
           </div>
 
-          <div className="flex shrink-0 items-center justify-between">
-            <div className="flex items-center text-gray-600 text-sm">
+          <div className="flex shrink-0 items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center text-gray-600 text-sm">
               <User className="mr-2 h-4 w-4 shrink-0" />
-              <span>{study.instructor}</span>
+              <span className="truncate">{study.instructor}</span>
             </div>
-            <Badge variant="outline" className="border-gray-300 text-gray-600">
+            <Badge
+              variant="outline"
+              className="shrink-0 border-gray-300 text-gray-600"
+            >
               #{StudyCategoryLabels[study.category]}
             </Badge>
           </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일 개선**
  * 스터디 카드의 상호작용 및 포인터 동작 스타일을 개선했습니다.
  * 강사 정보 섹션의 레이아웃 배치를 최적화하여 더 나은 정렬을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->